### PR TITLE
Supported namespaces in UniTask ver 7.0 or later

### DIFF
--- a/Assets/VRUIParts/JapaneseEnglishKeyboard/Scripts/KanjiConverter.cs
+++ b/Assets/VRUIParts/JapaneseEnglishKeyboard/Scripts/KanjiConverter.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UniRx.Async;
 using UnityEngine.Networking;
 using System;
+using Cysharp.Threading.Tasks;
 
 namespace VRUIParts
 {


### PR DESCRIPTION
UniRX 7.1.0 でプロジェクトを作成した場合に、UniRX側の変更でネームスペースの解決ができなくなっていたため修正しました。